### PR TITLE
Temporarily pin the PG version in molecule

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,7 +21,9 @@ provisioner:
     host_vars:
       omero-all:
         omero_server_systemd_require_network: false
-
+        # Temporary workaround for
+        # https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
+        postgresql_package_version: 9.6.13
 scenario:
   name: default
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -21,6 +21,7 @@ provisioner:
     host_vars:
       omero-all:
         omero_server_systemd_require_network: false
+        postgresql_version: "9.6"
         # Temporary workaround for
         # https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929
         postgresql_package_version: 9.6.13

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: ome.postgresql
-  version: 3.1.0
+  version: 3.2.0
 
 - src: ome.omero_server
   version: 2.0.6


### PR DESCRIPTION
See https://forum.image.sc/t/fyi-not-possible-to-create-new-omero-instance-with-latest-postgresql-versions/26929