### PR TITLE
Add postgresql_clients to requirements

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,6 +3,9 @@
 - src: ome.postgresql
   version: 5.2.0
 
+- src: ome.postgresql_client
+  version: 0.2.0
+
 - src: ome.omero_server
   version: 4.0.2
 


### PR DESCRIPTION
As discussed in https://github.com/ome/ansible-example-omero-onenode/pull/11#issuecomment-1210880812, the missing item in the ``requirements.yml`` when run on a clean CentOS 7 machine was causing 

```
TASK [ome.postgresql_client : postgres | install client packages] ****************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "No package matching 'postgresql13' found available, installed or updated", "rc": 126, "results": ["No package matching 'postgresql13' found available, installed or updated"]}
```

With this PR, this error is removed, and the playbook was run to the end successfully.

cc @sbesson 
