### PR TITLE
Add the self_signed certs to server role variables

### DIFF
--- a/debian.yml
+++ b/debian.yml
@@ -1,3 +1,2 @@
 ---
-omero_server_selfsigned_certificates: true
 ansible_python_interpreter: /usr/bin/python3

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,7 +15,7 @@
           password: omero
           databases: [omero]
     - role: ome.omero_server
-      omero_server_selfsigned_certificates: True
+      omero_server_selfsigned_certificates: true
       omero_server_rootpassword: ChangeMe
     - role: ome.omero_web
   vars:

--- a/playbook.yml
+++ b/playbook.yml
@@ -15,6 +15,7 @@
           password: omero
           databases: [omero]
     - role: ome.omero_server
+      omero_server_selfsigned_certificates: True
       omero_server_rootpassword: ChangeMe
     - role: ome.omero_web
   vars:


### PR DESCRIPTION
Should fix https://github.com/ome/ansible-example-omero-onenode/issues/14

Tested with this setup on freshly created CentOS 7 as per workflow captured in https://github.com/ome/ansible-example-omero-onenode/issues/13 and the problem with SSL handshake was solved.

cc @sbesson 