### PR TITLE
Add web conf

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -20,5 +20,6 @@
     - role: ome.omero_web
       omero_web_config_set:
         omero.web.application_server.host: "0.0.0.0"
+        omero.web.debug: true
   vars:
     postgresql_version: "13"

--- a/playbook.yml
+++ b/playbook.yml
@@ -18,5 +18,7 @@
       omero_server_selfsigned_certificates: true
       omero_server_rootpassword: ChangeMe
     - role: ome.omero_web
+      omero_web_config_set:
+        omero.web.application_server.host: "0.0.0.0"
   vars:
     postgresql_version: "13"


### PR DESCRIPTION
This fixes https://github.com/ome/ansible-example-omero-onenode/issues/13

cc @sbesson @jburel 

Tested by running the playbook in the setup described in https://github.com/ome/ansible-example-omero-onenode/issues/13
Tested:
- insight (including import)
- web (create new group/user, new P/D, viewing image in old viewer as iviewer is not installed in this minimal setup)
- cli (connect and import an image)
All worked fine.

![Screenshot 2022-09-07 at 16 28 01](https://user-images.githubusercontent.com/2478303/188918161-45e76f09-98c6-4dc2-9f0e-3c3e2838bc34.png)

